### PR TITLE
Add static site skeleton and architecture documentation

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+example.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# sitev2
-version 2 pour le site en teste avec codex
+# Nova Vox Interstellar
+
+Prototype statique du site communautaire francophone dédié à EVE Online. Ce dépôt contient une première ébauche de l'architecture et des pages conformément au plan d'information.
+
+## Structure
+- `index.html` : page d'accueil et navigation principale.
+- Dossiers des rubriques : `edition-semaine/`, `analyse-financiere/`, `temoignages/`, `cartes-batailles/`, `archives/`, `premium/`, `a-propos/`, `contact/`.
+- `posts/` : exemples de contenus.
+- `assets/` : styles et scripts communs.
+- `docs/architecture.md` : objectifs, sitemap et types de contenu.
+
+Pour l'instant, le site est purement statique et sert de base à l'implémentation future.

--- a/a-propos/index.html
+++ b/a-propos/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>À propos</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>À propos</h1>
+  <p>Charte éditoriale et mentions.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/analyse-financiere/index.html
+++ b/analyse-financiere/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Analyse financière</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>Analyse financière</h1>
+  <p>Données de marché et analyses PLEX.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/archives/index.html
+++ b/archives/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Archives</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>Archives</h1>
+  <p>Recherche de toutes les publications.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,2 @@
+const SITE_BASE = '';
+console.log('Nova Vox Interstellar loaded');

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,1 @@
+body{background-color:#0a0d12;color:#e6e9ef;font-family:sans-serif;margin:0;padding:0;}nav{background:#0f141b;padding:1rem;}nav a{color:#21c7d9;margin-right:1rem;text-decoration:none;}main{max-width:1100px;margin:1rem auto;padding:0 1rem;}h1{font-size:2rem;margin-top:0;}

--- a/cartes-batailles/index.html
+++ b/cartes-batailles/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Cartes & batailles</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>Cartes & batailles</h1>
+  <p>Rapports de conflits et positions des flottes.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Contact</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>Contact</h1>
+  <p>Envoyez un message à <a href="mailto:contact@example.com">contact@example.com</a>.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,27 @@
+# Nova Vox Interstellar – Architecture
+
+## 1. Buts & contraintes
+- Média francophone EVE Online : actualités, analyses marchés, cartes/batailles, témoignages.
+- Rigueur éditoriale : faits sourcés, analyses séparées, corrections datées.
+- Accessibilité & performance : thème sombre lisible, responsive, images WebP, JS minimal.
+- Évolutif : déploiement statique GitHub Pages, migration possible vers WordPress auto‑hébergé.
+
+## 2. Sitemap
+- Accueil `/`
+- Édition de la semaine `/edition-semaine/`
+- Analyse financière `/analyse-financiere/`
+- Témoignages `/temoignages/`
+- Cartes & batailles `/cartes-batailles/`
+- Archives `/archives/`
+- Premium `/premium/`
+- À propos `/a-propos/`
+- Contact `/contact/`
+
+## 4. Types de contenu
+### Article générique
+Champs principaux : `title`, `chapeau`, `image_une`, `category`, `tags`, `date_publication`, `auteur`, `sources`, `faits_verifies`, `analyse`, `impact_joueurs_fr`, `corrections`, `excerpt`, `slug`.
+
+### Options spécifiques
+- **Analyse PLEX** : `prix_7j`, `prix_30j`, `ecart_pct`, `sources_marche`.
+- **Rapport de bataille** : `systeme`, `region`, `debut`, `fin`, `cotes`, `isk_perdus_total`, `vaisseaux_détruits`, liens `zKill`/`Dotlan`.
+- **Témoignage pilote** : `pilote`, `corpo/alliance`, `zone`, `liens_killmails`.

--- a/edition-semaine/index.html
+++ b/edition-semaine/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Édition de la semaine</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>Édition de la semaine</h1>
+  <p>Articles hebdomadaires.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Nova Vox Interstellar</title>
+<link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes & batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
+</nav>
+<main>
+  <h1>Nova Vox Interstellar</h1>
+  <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
+</main>
+<script src="assets/script.js"></script>
+</body>
+</html>

--- a/posts/exemple-article.html
+++ b/posts/exemple-article.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Exemple d'article</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <article>
+    <header>
+      <h1>Titre de l'article</h1>
+      <p class="chapeau">Résumé court de l'article.</p>
+      <img src="image.webp" alt="Image d'illustration" />
+      <p class="meta">Catégorie: édition-semaine | Date: 2024-01-01 | Auteur: Capsuleer</p>
+    </header>
+    <section>
+      <h2>Faits vérifiés</h2>
+      <ul>
+        <li>Fait 1 avec source <a href="#">zKill</a></li>
+      </ul>
+    </section>
+    <section>
+      <h2>Analyse</h2>
+      <p>Texte d'analyse avec hypothèses.</p>
+    </section>
+    <section>
+      <h2>Impact pour les joueurs FR</h2>
+      <ul>
+        <li>Point d'impact</li>
+      </ul>
+    </section>
+    <footer>
+      <p>Sources: <a href="#">Dotlan</a></p>
+      <p>Corrections: aucune</p>
+    </footer>
+  </article>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/premium/index.html
+++ b/premium/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Premium</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>Premium</h1>
+  <p>Accès réservé aux membres soutenant le projet.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>

--- a/temoignages/index.html
+++ b/temoignages/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Témoignages de pilotes</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<nav>
+  <a href="../index.html">Accueil</a>
+</nav>
+<main>
+  <h1>Témoignages de pilotes</h1>
+  <p>Récits de la communauté.</p>
+</main>
+<script src="../assets/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document goals, sitemap, and content types for Nova Vox Interstellar
- scaffold static pages for sitemap with basic navigation
- add example article structure and shared assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40a1adce0832f9df2711c69d12f51