### PR TITLE
Add hero and latest-posts sections to homepage

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -5,9 +5,22 @@ document.addEventListener('DOMContentLoaded', () => {
   const main = document.querySelector('main');
   if (!main) return;
 
-  fetch('../posts/index.json')
+  fetch(`${SITE_BASE}/posts/index.json`)
     .then(r => r.json())
     .then(data => {
+      const latestContainer = document.getElementById('latest-posts');
+      if (latestContainer) {
+        const latest = [...data]
+          .sort((a, b) => new Date(b.date_publication) - new Date(a.date_publication))
+          .slice(0, 6);
+        latest.forEach(p => {
+          const card = document.createElement('article');
+          card.className = 'post-card';
+          card.innerHTML = `<h3><a href="${SITE_BASE}/posts/${p.slug}.html">${p.title}</a></h3>\n<p>${p.excerpt}</p>\n<small>${p.date_publication}</small>`;
+          latestContainer.appendChild(card);
+        });
+      }
+
       const currentSection = window.location.pathname.split('/').filter(Boolean).pop();
       const categories = new Set(data.map(p => p.category));
       if (currentSection !== 'archives' && !categories.has(currentSection)) return;
@@ -27,7 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const card = document.createElement('article');
         card.className = 'post-card';
         card.dataset.tags = p.tags.join(',');
-        card.innerHTML = `<h2><a href="../posts/${p.slug}.html">${p.title}</a></h2>\n<p>${p.excerpt}</p>\n<small>${p.date_publication}</small>`;
+        card.innerHTML = `<h2><a href="${SITE_BASE}/posts/${p.slug}.html">${p.title}</a></h2>\n<p>${p.excerpt}</p>\n<small>${p.date_publication}</small>`;
         list.appendChild(card);
       });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -29,3 +29,36 @@ h1 {
   font-size: 2rem;
   margin-top: 0;
 }
+#hero {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+#hero .cta {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #21c7d9;
+  color: #0a0d12;
+  text-decoration: none;
+}
+#latest-posts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+#rubriques .columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+#rubriques .column {
+  flex: 1;
+  min-width: 200px;
+  border: 1px solid #21c7d9;
+  padding: 1rem;
+}
+#method ul,
+#subscribe ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+}

--- a/index.html
+++ b/index.html
@@ -20,8 +20,51 @@
 </nav>
 
 <main>
-  <h1>Nova Vox Interstellar</h1>
-  <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
+  <section id="hero">
+    <h1>Nova Vox Interstellar</h1>
+    <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
+    <a href="/archives/" class="cta">Voir toutes les publications</a>
+  </section>
+
+  <section id="latest">
+    <h2>Dernières publications</h2>
+    <div id="latest-posts"></div>
+  </section>
+
+  <section id="rubriques">
+    <h2>Rubriques</h2>
+    <div class="columns">
+      <div class="column">
+        <h3>Édition de la semaine</h3>
+        <p>Chaque semaine, un condensé des événements majeurs.</p>
+      </div>
+      <div class="column">
+        <h3>Analyse financière</h3>
+        <p>Décryptage des marchés et tendances économiques.</p>
+      </div>
+      <div class="column">
+        <h3>Témoignages</h3>
+        <p>Récits vécus par les pilotes de la galaxie.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="method">
+    <h2>Notre méthode</h2>
+    <ul>
+      <li>Rigueur</li>
+      <li>Sources</li>
+      <li>Corrections</li>
+    </ul>
+  </section>
+
+  <section id="subscribe">
+    <h2>Abonnement</h2>
+    <ul>
+      <li><a href="/rss.xml">Flux RSS</a></li>
+      <li><a href="https://discord.gg/novavox">Discord</a></li>
+    </ul>
+  </section>
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -9,8 +9,51 @@
 <body>
 <!-- include:header -->
 <main>
-  <h1>Nova Vox Interstellar</h1>
-  <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
+  <section id="hero">
+    <h1>Nova Vox Interstellar</h1>
+    <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
+    <a href="/archives/" class="cta">Voir toutes les publications</a>
+  </section>
+
+  <section id="latest">
+    <h2>Dernières publications</h2>
+    <div id="latest-posts"></div>
+  </section>
+
+  <section id="rubriques">
+    <h2>Rubriques</h2>
+    <div class="columns">
+      <div class="column">
+        <h3>Édition de la semaine</h3>
+        <p>Chaque semaine, un condensé des événements majeurs.</p>
+      </div>
+      <div class="column">
+        <h3>Analyse financière</h3>
+        <p>Décryptage des marchés et tendances économiques.</p>
+      </div>
+      <div class="column">
+        <h3>Témoignages</h3>
+        <p>Récits vécus par les pilotes de la galaxie.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="method">
+    <h2>Notre méthode</h2>
+    <ul>
+      <li>Rigueur</li>
+      <li>Sources</li>
+      <li>Corrections</li>
+    </ul>
+  </section>
+
+  <section id="subscribe">
+    <h2>Abonnement</h2>
+    <ul>
+      <li><a href="/rss.xml">Flux RSS</a></li>
+      <li><a href="https://discord.gg/novavox">Discord</a></li>
+    </ul>
+  </section>
 </main>
 <!-- include:footer -->
 <script src="/assets/script.js"></script>


### PR DESCRIPTION
## Summary
- add hero, latest articles, rubric highlights, method and subscription sections on homepage
- style new sections and fetch six latest posts via JavaScript

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b41126eb60832f89100d56261d162e