### PR TITLE
Add reusable article blocks and styling

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,6 +1,59 @@
 const SITE_BASE = '';
 console.log('Nova Vox Interstellar loaded');
 
+function createCardArticle(p, heading = 'h2') {
+  const card = document.createElement('article');
+  card.className = 'card-article';
+  card.innerHTML = `<${heading}><a href="${SITE_BASE}/posts/${p.slug}.html">${p.title}</a></${heading}>\n<p>${p.excerpt}</p>\n<small>${p.date_publication}</small>`;
+  return card;
+}
+
+function blocContexte(html) {
+  const section = document.createElement('section');
+  section.className = 'bloc-contexte';
+  section.innerHTML = `<h2>Contexte</h2>${html}`;
+  return section;
+}
+
+function blocFaits(items) {
+  const section = document.createElement('section');
+  section.className = 'bloc-faits';
+  const list = items.map(i => `<li>${i}</li>`).join('');
+  section.innerHTML = `<h2>Faits vérifiés</h2><ul>${list}</ul>`;
+  return section;
+}
+
+function blocAnalyse(html) {
+  const section = document.createElement('section');
+  section.className = 'bloc-analyse';
+  section.innerHTML = `<h2>Analyse</h2>${html}`;
+  return section;
+}
+
+function blocImpact(items) {
+  const section = document.createElement('section');
+  section.className = 'bloc-impact';
+  const list = items.map(i => `<li>${i}</li>`).join('');
+  section.innerHTML = `<h2>Impact pour les joueurs FR</h2><ul>${list}</ul>`;
+  return section;
+}
+
+function banniereMaj(message) {
+  const banner = document.createElement('div');
+  banner.className = 'banniere-maj';
+  banner.textContent = message;
+  return banner;
+}
+
+window.NV = {
+  createCardArticle,
+  blocContexte,
+  blocFaits,
+  blocAnalyse,
+  blocImpact,
+  banniereMaj,
+};
+
 document.addEventListener('DOMContentLoaded', () => {
   const main = document.querySelector('main');
   if (!main) return;
@@ -14,9 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
           .sort((a, b) => new Date(b.date_publication) - new Date(a.date_publication))
           .slice(0, 6);
         latest.forEach(p => {
-          const card = document.createElement('article');
-          card.className = 'post-card';
-          card.innerHTML = `<h3><a href="${SITE_BASE}/posts/${p.slug}.html">${p.title}</a></h3>\n<p>${p.excerpt}</p>\n<small>${p.date_publication}</small>`;
+          const card = createCardArticle(p, 'h3');
           latestContainer.appendChild(card);
         });
       }
@@ -37,10 +88,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const posts = currentSection === 'archives' ? data : data.filter(p => p.category === currentSection);
       posts.forEach(p => {
-        const card = document.createElement('article');
-        card.className = 'post-card';
+        const card = createCardArticle(p);
         card.dataset.tags = p.tags.join(',');
-        card.innerHTML = `<h2><a href="${SITE_BASE}/posts/${p.slug}.html">${p.title}</a></h2>\n<p>${p.excerpt}</p>\n<small>${p.date_publication}</small>`;
         list.appendChild(card);
       });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,5 +1,3 @@
-
-body{background-color:#0a0d12;color:#e6e9ef;font-family:sans-serif;margin:0;padding:0;}nav{background:#0f141b;padding:1rem;}nav a{color:#21c7d9;margin-right:1rem;text-decoration:none;}main{max-width:1100px;margin:1rem auto;padding:0 1rem;}h1{font-size:2rem;margin-top:0;}#tag-filter{margin:1rem 0;padding:.5rem;width:100%;}.post-card{border:1px solid #21c7d9;padding:1rem;margin:1rem 0;}.post-card h2{margin:0 0 .5rem;}
 body {
   background-color: #0a0d12;
   color: #e6e9ef;
@@ -61,4 +59,39 @@ h1 {
 #subscribe ul {
   list-style: disc;
   padding-left: 1.5rem;
+}
+
+.card-article {
+  border: 1px solid #21c7d9;
+  padding: 1rem;
+  margin: 1rem 0;
+  background: #0f141b;
+}
+.card-article h2,
+.card-article h3 {
+  margin-top: 0;
+}
+
+.bloc-contexte,
+.bloc-faits,
+.bloc-analyse,
+.bloc-impact {
+  padding: 1rem;
+  margin: 1rem 0;
+  background: #0f141b;
+  border-left: 4px solid #21c7d9;
+}
+.bloc-contexte h2,
+.bloc-faits h2,
+.bloc-analyse h2,
+.bloc-impact h2 {
+  margin-top: 0;
+}
+
+.banniere-maj {
+  background: #21c7d9;
+  color: #0a0d12;
+  padding: 0.5rem 1rem;
+  text-align: center;
+  margin: 1rem 0;
 }

--- a/partials/blocs.html
+++ b/partials/blocs.html
@@ -1,0 +1,40 @@
+<!-- Snippets for reusable content blocks -->
+<template id="card-article">
+  <article class="card-article">
+    <h2><a href="#"></a></h2>
+    <p></p>
+    <small></small>
+  </article>
+</template>
+
+<template id="bloc-contexte">
+  <section class="bloc-contexte">
+    <h2>Contexte</h2>
+    <p></p>
+  </section>
+</template>
+
+<template id="bloc-faits">
+  <section class="bloc-faits">
+    <h2>Faits vérifiés</h2>
+    <ul></ul>
+  </section>
+</template>
+
+<template id="bloc-analyse">
+  <section class="bloc-analyse">
+    <h2>Analyse</h2>
+    <p></p>
+  </section>
+</template>
+
+<template id="bloc-impact">
+  <section class="bloc-impact">
+    <h2>Impact pour les joueurs FR</h2>
+    <ul></ul>
+  </section>
+</template>
+
+<template id="banniere-maj">
+  <div class="banniere-maj"></div>
+</template>


### PR DESCRIPTION
## Summary
- style content and card blocks: article cards, context/fact/analysis/impact sections and update banner
- provide reusable HTML templates and JS helpers for these blocks
- switch list rendering to new card helpers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b412473664832faa2a37c1eb8899e3