### PR TITLE
Add archive search with filtering

### DIFF
--- a/archives/index.html
+++ b/archives/index.html
@@ -22,6 +22,7 @@
 <main>
   <h1>Archives</h1>
   <p>Recherche de toutes les publications.</p>
+  <input type="search" id="archives-search" placeholder="Rechercher..." />
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>

--- a/assets/script.js
+++ b/assets/script.js
@@ -76,31 +76,48 @@ document.addEventListener('DOMContentLoaded', () => {
       const categories = new Set(data.map(p => p.category));
       if (currentSection !== 'archives' && !categories.has(currentSection)) return;
 
-      const search = document.createElement('input');
-      search.type = 'search';
-      search.id = 'tag-filter';
-      search.placeholder = 'Filtrer par tag';
-      main.appendChild(search);
+      let search;
+      if (currentSection === 'archives') {
+        search = document.getElementById('archives-search');
+      } else {
+        search = document.createElement('input');
+        search.type = 'search';
+        search.id = 'tag-filter';
+        search.placeholder = 'Filtrer par tag';
+        main.appendChild(search);
+      }
 
       const list = document.createElement('div');
       list.id = 'posts-list';
       main.appendChild(list);
 
+      const noResults = document.createElement('p');
+      noResults.id = 'no-results';
+      noResults.textContent = 'Aucun résultat';
+      noResults.style.display = 'none';
+      main.appendChild(noResults);
+
       const posts = currentSection === 'archives' ? data : data.filter(p => p.category === currentSection);
       posts.forEach(p => {
         const card = createCardArticle(p);
         card.dataset.tags = p.tags.join(',');
+        card.dataset.search = `${p.title} ${p.category} ${(p.source || '')} ${(p.sources || []).join(' ')}`.toLowerCase();
         list.appendChild(card);
       });
 
       const cards = Array.from(list.children);
-      search.addEventListener('input', () => {
+      const filterCards = () => {
         const q = search.value.trim().toLowerCase();
+        let visible = 0;
         cards.forEach(card => {
-          const tags = card.dataset.tags.toLowerCase();
-          card.style.display = q === '' || tags.includes(q) ? '' : 'none';
+          const text = currentSection === 'archives' ? card.dataset.search : card.dataset.tags.toLowerCase();
+          const show = q === '' || text.includes(q);
+          card.style.display = show ? '' : 'none';
+          if (show) visible++;
         });
-      });
+        noResults.style.display = visible === 0 ? '' : 'none';
+      };
+      search.addEventListener('input', filterCards);
     })
     .catch(err => console.error('Erreur chargement index', err));
 });

--- a/src/archives/index.html
+++ b/src/archives/index.html
@@ -11,6 +11,7 @@
 <main>
   <h1>Archives</h1>
   <p>Recherche de toutes les publications.</p>
+  <input type="search" id="archives-search" placeholder="Rechercher..." />
 </main>
 <!-- include:footer -->
 <script src="/assets/script.js"></script>


### PR DESCRIPTION
## Summary
- Add search field to archives page template and built output
- Filter archive posts by title, category, or source with live search
- Show a fallback "Aucun résultat" message when no posts match

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b41364b2a4832f8ad14f3587218082