### PR TITLE
Add shared layout and article index

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+example.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# sitev2
-version 2 pour le site en teste avec codex
+# Nova Vox Interstellar
+
+Prototype statique du site communautaire francophone dédié à EVE Online. Ce dépôt contient une première ébauche de l'architecture et des pages conformément au plan d'information.
+
+## Structure
+- `index.html` : page d'accueil et navigation principale.
+- Dossiers des rubriques : `edition-semaine/`, `analyse-financiere/`, `temoignages/`, `cartes-batailles/`, `archives/`, `premium/`, `a-propos/`, `contact/`.
+- `posts/` : exemples de contenus.
+- `assets/` : styles et scripts communs.
+- `docs/architecture.md` : objectifs, sitemap et types de contenu.
+
+Pour l'instant, le site est purement statique et sert de base à l'implémentation future.

--- a/a-propos/index.html
+++ b/a-propos/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>À propos</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>À propos</h1>
+  <p>Charte éditoriale et mentions.</p>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/analyse-financiere/index.html
+++ b/analyse-financiere/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Analyse financière</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Analyse financière</h1>
+  <input type="search" id="tag-filter" placeholder="Filtrer par tag" />
+  <div id="articles" data-category="analyse-financiere"></div>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/archives/index.html
+++ b/archives/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Archives</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Archives</h1>
+  <input type="search" id="tag-filter" placeholder="Filtrer par tag" />
+  <div id="articles"></div>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,54 @@
+const currentScript = document.currentScript;
+const SITE_BASE = currentScript.getAttribute('data-base') || '';
+
+async function loadPartials(){
+  const header = document.getElementById('header');
+  if(header){
+    const res = await fetch(SITE_BASE + 'partials/header.html');
+    header.innerHTML = await res.text();
+    header.querySelectorAll('a[data-href]').forEach(a=>{
+      a.href = SITE_BASE + a.getAttribute('data-href');
+    });
+  }
+  const footer = document.getElementById('footer');
+  if(footer){
+    const res = await fetch(SITE_BASE + 'partials/footer.html');
+    footer.innerHTML = await res.text();
+  }
+}
+
+function createCard(article){
+  const div = document.createElement('article');
+  div.className = 'card-article';
+  div.dataset.tags = article.tags.join(' ').toLowerCase();
+  div.innerHTML = `<h2><a href="${SITE_BASE}posts/${article.slug}.html">${article.title}</a></h2>`+
+                  `<p class="meta">${article.date_publication}</p>`+
+                  `<p>${article.excerpt}</p>`;
+  return div;
+}
+
+async function loadArticles(){
+  const container = document.getElementById('articles');
+  if(!container) return;
+  const res = await fetch(SITE_BASE + 'posts/index.json');
+  const posts = await res.json();
+  const category = container.dataset.category;
+  posts
+    .filter(p => !category || p.category === category)
+    .sort((a,b)=> new Date(b.date_publication) - new Date(a.date_publication))
+    .forEach(p => container.appendChild(createCard(p)));
+  const filter = document.getElementById('tag-filter');
+  if(filter){
+    filter.addEventListener('input', e => {
+      const tag = e.target.value.toLowerCase();
+      Array.from(container.children).forEach(card => {
+        card.style.display = !tag || card.dataset.tags.includes(tag) ? '' : 'none';
+      });
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadPartials().then(loadArticles);
+  console.log('Nova Vox Interstellar loaded');
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,50 @@
+body {
+  background-color: #0a0d12;
+  color: #e6e9ef;
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+}
+nav {
+  background: #0f141b;
+  padding: 1rem;
+}
+nav a {
+  color: #21c7d9;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+main {
+  max-width: 1100px;
+  margin: 1rem auto;
+  padding: 0 1rem;
+}
+h1 {
+  font-size: 2rem;
+  margin-top: 0;
+}
+.card-article {
+  background: #0f141b;
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.card-article h2 {
+  margin-top: 0;
+}
+.bloc-contexte,
+.bloc-faits,
+.bloc-analyse,
+.bloc-impact {
+  background: #0f141b;
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.banniere-maj {
+  background: #21c7d9;
+  color: #0a0d12;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  border-radius: 12px;
+}

--- a/cartes-batailles/index.html
+++ b/cartes-batailles/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Cartes & batailles</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Cartes & batailles</h1>
+  <input type="search" id="tag-filter" placeholder="Filtrer par tag" />
+  <div id="articles" data-category="cartes-batailles"></div>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Contact</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Contact</h1>
+  <p>Envoyez un message à <a href="mailto:contact@example.com">contact@example.com</a>.</p>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,27 @@
+# Nova Vox Interstellar – Architecture
+
+## 1. Buts & contraintes
+- Média francophone EVE Online : actualités, analyses marchés, cartes/batailles, témoignages.
+- Rigueur éditoriale : faits sourcés, analyses séparées, corrections datées.
+- Accessibilité & performance : thème sombre lisible, responsive, images WebP, JS minimal.
+- Évolutif : déploiement statique GitHub Pages, migration possible vers WordPress auto‑hébergé.
+
+## 2. Sitemap
+- Accueil `/`
+- Édition de la semaine `/edition-semaine/`
+- Analyse financière `/analyse-financiere/`
+- Témoignages `/temoignages/`
+- Cartes & batailles `/cartes-batailles/`
+- Archives `/archives/`
+- Premium `/premium/`
+- À propos `/a-propos/`
+- Contact `/contact/`
+
+## 4. Types de contenu
+### Article générique
+Champs principaux : `title`, `chapeau`, `image_une`, `category`, `tags`, `date_publication`, `auteur`, `sources`, `faits_verifies`, `analyse`, `impact_joueurs_fr`, `corrections`, `excerpt`, `slug`.
+
+### Options spécifiques
+- **Analyse PLEX** : `prix_7j`, `prix_30j`, `ecart_pct`, `sources_marche`.
+- **Rapport de bataille** : `systeme`, `region`, `debut`, `fin`, `cotes`, `isk_perdus_total`, `vaisseaux_détruits`, liens `zKill`/`Dotlan`.
+- **Témoignage pilote** : `pilote`, `corpo/alliance`, `zone`, `liens_killmails`.

--- a/edition-semaine/index.html
+++ b/edition-semaine/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Édition de la semaine</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Édition de la semaine</h1>
+  <input type="search" id="tag-filter" placeholder="Filtrer par tag" />
+  <div id="articles" data-category="edition-semaine"></div>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Nova Vox Interstellar</title>
+<link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Nova Vox Interstellar</h1>
+  <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
+</main>
+<div id="footer"></div>
+<script src="assets/script.js" data-base=""></script>
+</body>
+</html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>&copy; 2024 Nova Vox Interstellar</p>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,11 @@
+<nav aria-label="Navigation principale">
+  <a data-href="index.html">Accueil</a>
+  <a data-href="edition-semaine/">Édition de la semaine</a>
+  <a data-href="analyse-financiere/">Analyse financière</a>
+  <a data-href="temoignages/">Témoignages</a>
+  <a data-href="cartes-batailles/">Cartes & batailles</a>
+  <a data-href="archives/">Archives</a>
+  <a data-href="premium/">Premium</a>
+  <a data-href="a-propos/">À propos</a>
+  <a data-href="contact/">Contact</a>
+</nav>

--- a/posts/deuxieme-article.html
+++ b/posts/deuxieme-article.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Deuxième article</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <article>
+    <header class="bloc-contexte">
+      <h1>Deuxième article</h1>
+      <p class="chapeau">Autre résumé d'article.</p>
+      <img src="image2.webp" alt="Illustration" />
+      <p class="meta">Catégorie: analyse-financiere | Date: 2024-02-01 | Auteur: Capsuleer</p>
+    </header>
+    <section class="bloc-faits">
+      <h2>Faits vérifiés</h2>
+      <ul>
+        <li>Donnée confirmée <a href="#">CCP</a></li>
+      </ul>
+    </section>
+    <section class="bloc-analyse">
+      <h2>Analyse</h2>
+      <p>Analyse du marché PLEX.</p>
+    </section>
+    <section class="bloc-impact">
+      <h2>Impact pour les joueurs FR</h2>
+      <ul>
+        <li>Conseil économique</li>
+      </ul>
+    </section>
+    <footer class="bloc-contexte">
+      <p>Sources: <a href="#">CCP</a></p>
+      <p>Corrections: aucune</p>
+    </footer>
+  </article>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/posts/exemple-article.html
+++ b/posts/exemple-article.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Exemple d'article</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <article>
+    <header class="bloc-contexte">
+      <h1>Titre de l'article</h1>
+      <p class="chapeau">Résumé court de l'article.</p>
+      <img src="image.webp" alt="Image d'illustration" />
+      <p class="meta">Catégorie: édition-semaine | Date: 2024-01-01 | Auteur: Capsuleer</p>
+    </header>
+    <section class="bloc-faits">
+      <h2>Faits vérifiés</h2>
+      <ul>
+        <li>Fait 1 avec source <a href="#">zKill</a></li>
+      </ul>
+    </section>
+    <section class="bloc-analyse">
+      <h2>Analyse</h2>
+      <p>Texte d'analyse avec hypothèses.</p>
+    </section>
+    <section class="bloc-impact">
+      <h2>Impact pour les joueurs FR</h2>
+      <ul>
+        <li>Point d'impact</li>
+      </ul>
+    </section>
+    <footer class="bloc-contexte">
+      <p>Sources: <a href="#">Dotlan</a></p>
+      <p>Corrections: aucune</p>
+    </footer>
+  </article>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/posts/index.json
+++ b/posts/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "title": "Titre de l'article",
+    "slug": "exemple-article",
+    "category": "edition-semaine",
+    "tags": ["exemple"],
+    "date_publication": "2024-01-01",
+    "excerpt": "Résumé court de l'article."
+  },
+  {
+    "title": "Deuxième article",
+    "slug": "deuxieme-article",
+    "category": "analyse-financiere",
+    "tags": ["marche"],
+    "date_publication": "2024-02-01",
+    "excerpt": "Autre résumé d'article."
+  }
+]

--- a/premium/index.html
+++ b/premium/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Premium</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Premium</h1>
+  <p>Accès réservé aux membres soutenant le projet.</p>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>

--- a/temoignages/index.html
+++ b/temoignages/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Témoignages de pilotes</title>
+<link rel="stylesheet" href="../assets/style.css" />
+</head>
+<body>
+<div id="header"></div>
+<main>
+  <h1>Témoignages de pilotes</h1>
+  <input type="search" id="tag-filter" placeholder="Filtrer par tag" />
+  <div id="articles" data-category="temoignages"></div>
+</main>
+<div id="footer"></div>
+<script src="../assets/script.js" data-base="../"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add reusable header and footer partials for consistent navigation
- Implement client-side article index with tag filtering and card component styles
- Include two example articles and metadata JSON for dynamic lists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40a1adce0832f9df2711c69d12f51