### PR TITLE
Use relative paths with base tag and add exploration guide

### DIFF
--- a/a-propos/index.html
+++ b/a-propos/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>À propos</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -25,9 +26,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/analyse-financiere/index.html
+++ b/analyse-financiere/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Analyse financière</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -25,9 +26,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/archives/index.html
+++ b/archives/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Archives</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -26,9 +27,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/cartes-batailles/index.html
+++ b/cartes-batailles/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Cartes & batailles</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -25,9 +26,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Contact</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -25,9 +26,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/edition-semaine/index.html
+++ b/edition-semaine/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Édition de la semaine</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -25,9 +26,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,26 +4,27 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Nova Vox Interstellar</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
   <section id="hero">
     <h1>Nova Vox Interstellar</h1>
     <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
-    <a href="/archives/" class="cta">Voir toutes les publications</a>
+    <a href="archives/" class="cta">Voir toutes les publications</a>
   </section>
 
   <section id="latest">
@@ -61,16 +62,16 @@
   <section id="subscribe">
     <h2>Abonnement</h2>
     <ul>
-      <li><a href="/rss.xml">Flux RSS</a></li>
+      <li><a href="rss.xml">Flux RSS</a></li>
       <li><a href="https://discord.gg/novavox">Discord</a></li>
     </ul>
   </section>
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,4 +1,4 @@
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,11 +1,11 @@
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>

--- a/posts/exemple-article.html
+++ b/posts/exemple-article.html
@@ -3,57 +3,70 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Exemple d'article</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<title>Débuter l'exploration</title>
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
   <article>
     <header>
-      <h1>Titre de l'article</h1>
-      <p class="chapeau">Résumé court de l'article.</p>
-      <img src="image.webp" alt="Image d'illustration" />
-      <p class="meta">Catégorie: édition-semaine | Date: 2024-01-01 | Auteur: Capsuleer</p>
+      <h1>Débuter l'exploration en 2024</h1>
+      <p class="chapeau">Un guide rapide pour partir à la recherche de signatures cosmiques.</p>
+      <img src="image.webp" alt="Scanner d'exploration" />
+      <p class="meta">Catégorie: édition-semaine | Date: 2024-05-20 | Auteur: Capsuleer</p>
     </header>
+
     <section>
-      <h2>Faits vérifiés</h2>
+      <h2>Équipement recommandé</h2>
       <ul>
-        <li>Fait 1 avec source <a href="#">zKill</a></li>
+        <li>Frégate d'exploration équipée d'un <strong>Core Probe Launcher</strong></li>
+        <li>8 <strong>Core Scanner Probes</strong></li>
+        <li>Module <strong>Relic Analyzer</strong> ou <strong>Data Analyzer</strong></li>
       </ul>
     </section>
+
     <section>
-      <h2>Analyse</h2>
-      <p>Texte d'analyse avec hypothèses.</p>
+      <h2>Repérer les signatures</h2>
+      <p>Utilisez le scanner système pour identifier les signatures cosmiques dans la région. Positionnez vos sondes et réduisez progressivement leur portée jusqu'à atteindre un signal de 100%.</p>
     </section>
+
+    <section>
+      <h2>Récompenses potentielles</h2>
+      <p>Les sites de données offrent des plans d'invention et des matériaux, tandis que les sites de reliques contiennent des composants de fabrication précieux.</p>
+    </section>
+
     <section>
       <h2>Impact pour les joueurs FR</h2>
       <ul>
-        <li>Point d'impact</li>
+        <li>Source de revenus accessible aux nouveaux pilotes</li>
+        <li>Introduction idéale aux mécaniques d'exploration</li>
       </ul>
     </section>
+
     <footer>
-      <p>Sources: <a href="#">Dotlan</a></p>
+      <p>Sources: <a href="https://wiki.eveuniversity.org/Exploration">EVE University</a></p>
       <p>Corrections: aucune</p>
     </footer>
   </article>
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/posts/index.json
+++ b/posts/index.json
@@ -1,11 +1,11 @@
 [
   {
-    "title": "Exemple d'article",
+    "title": "Débuter l'exploration en 2024",
     "slug": "exemple-article",
     "category": "edition-semaine",
-    "tags": ["hebdo", "plex"],
-    "date_publication": "2024-01-01",
-    "excerpt": "Résumé court de l'article."
+    "tags": ["exploration", "debutant"],
+    "date_publication": "2024-05-20",
+    "excerpt": "Un guide rapide pour débuter l'exploration des signatures cosmiques."
   },
   {
     "title": "Analyse des prix PLEX",

--- a/premium/index.html
+++ b/premium/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Premium</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -25,9 +26,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/a-propos/index.html
+++ b/src/a-propos/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>À propos</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -13,6 +14,6 @@
   <p>Charte éditoriale et mentions.</p>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/analyse-financiere/index.html
+++ b/src/analyse-financiere/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Analyse financière</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -13,6 +14,6 @@
   <p>Données de marché et analyses PLEX.</p>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/archives/index.html
+++ b/src/archives/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Archives</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -14,6 +15,6 @@
   <input type="search" id="archives-search" placeholder="Rechercher..." />
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/cartes-batailles/index.html
+++ b/src/cartes-batailles/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Cartes & batailles</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -13,6 +14,6 @@
   <p>Rapports de conflits et positions des flottes.</p>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/contact/index.html
+++ b/src/contact/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Contact</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -13,6 +14,6 @@
   <p>Envoyez un message à <a href="mailto:contact@example.com">contact@example.com</a>.</p>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/edition-semaine/index.html
+++ b/src/edition-semaine/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Édition de la semaine</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -13,6 +14,6 @@
   <p>Articles hebdomadaires.</p>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Nova Vox Interstellar</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -12,7 +13,7 @@
   <section id="hero">
     <h1>Nova Vox Interstellar</h1>
     <p>Bienvenue sur le hub francophone d'actualités EVE Online.</p>
-    <a href="/archives/" class="cta">Voir toutes les publications</a>
+    <a href="archives/" class="cta">Voir toutes les publications</a>
   </section>
 
   <section id="latest">
@@ -50,12 +51,12 @@
   <section id="subscribe">
     <h2>Abonnement</h2>
     <ul>
-      <li><a href="/rss.xml">Flux RSS</a></li>
+      <li><a href="rss.xml">Flux RSS</a></li>
       <li><a href="https://discord.gg/novavox">Discord</a></li>
     </ul>
   </section>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/posts/analyse-prix-plex.html
+++ b/src/posts/analyse-prix-plex.html
@@ -8,18 +8,7 @@
 <link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
-<nav aria-label="Navigation principale">
-  <a href="index.html">Accueil</a>
-  <a href="edition-semaine/">Édition de la semaine</a>
-  <a href="analyse-financiere/">Analyse financière</a>
-  <a href="temoignages/">Témoignages</a>
-  <a href="cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="archives/">Archives</a>
-  <a href="premium/">Premium</a>
-  <a href="a-propos/">À propos</a>
-  <a href="contact/">Contact</a>
-</nav>
-
+<!-- include:header -->
 <main>
   <article>
     <header>
@@ -35,11 +24,7 @@
     </footer>
   </article>
 </main>
-<footer>
-  <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
-</footer>
-
+<!-- include:footer -->
 <script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/posts/exemple-article.html
+++ b/src/posts/exemple-article.html
@@ -3,42 +3,55 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Exemple d'article</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<title>Débuter l'exploration</title>
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
 <main>
   <article>
     <header>
-      <h1>Titre de l'article</h1>
-      <p class="chapeau">Résumé court de l'article.</p>
-      <img src="image.webp" alt="Image d'illustration" />
-      <p class="meta">Catégorie: édition-semaine | Date: 2024-01-01 | Auteur: Capsuleer</p>
+      <h1>Débuter l'exploration en 2024</h1>
+      <p class="chapeau">Un guide rapide pour partir à la recherche de signatures cosmiques.</p>
+      <img src="image.webp" alt="Scanner d'exploration" />
+      <p class="meta">Catégorie: édition-semaine | Date: 2024-05-20 | Auteur: Capsuleer</p>
     </header>
+
     <section>
-      <h2>Faits vérifiés</h2>
+      <h2>Équipement recommandé</h2>
       <ul>
-        <li>Fait 1 avec source <a href="#">zKill</a></li>
+        <li>Frégate d'exploration équipée d'un <strong>Core Probe Launcher</strong></li>
+        <li>8 <strong>Core Scanner Probes</strong></li>
+        <li>Module <strong>Relic Analyzer</strong> ou <strong>Data Analyzer</strong></li>
       </ul>
     </section>
+
     <section>
-      <h2>Analyse</h2>
-      <p>Texte d'analyse avec hypothèses.</p>
+      <h2>Repérer les signatures</h2>
+      <p>Utilisez le scanner système pour identifier les signatures cosmiques dans la région. Positionnez vos sondes et réduisez progressivement leur portée jusqu'à atteindre un signal de 100%.</p>
     </section>
+
+    <section>
+      <h2>Récompenses potentielles</h2>
+      <p>Les sites de données offrent des plans d'invention et des matériaux, tandis que les sites de reliques contiennent des composants de fabrication précieux.</p>
+    </section>
+
     <section>
       <h2>Impact pour les joueurs FR</h2>
       <ul>
-        <li>Point d'impact</li>
+        <li>Source de revenus accessible aux nouveaux pilotes</li>
+        <li>Introduction idéale aux mécaniques d'exploration</li>
       </ul>
     </section>
+
     <footer>
-      <p>Sources: <a href="#">Dotlan</a></p>
+      <p>Sources: <a href="https://wiki.eveuniversity.org/Exploration">EVE University</a></p>
       <p>Corrections: aucune</p>
     </footer>
   </article>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/premium/index.html
+++ b/src/premium/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Premium</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -13,6 +14,6 @@
   <p>Accès réservé aux membres soutenant le projet.</p>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/src/temoignages/index.html
+++ b/src/temoignages/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Témoignages de pilotes</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <!-- include:header -->
@@ -13,6 +14,6 @@
   <p>Récits de la communauté.</p>
 </main>
 <!-- include:footer -->
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/temoignages/index.html
+++ b/temoignages/index.html
@@ -4,19 +4,20 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Témoignages de pilotes</title>
-<link rel="stylesheet" href="/assets/style.css" />
+<base href="/sitev2/" />
+<link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
 <nav aria-label="Navigation principale">
-  <a href="/index.html">Accueil</a>
-  <a href="/edition-semaine/">Édition de la semaine</a>
-  <a href="/analyse-financiere/">Analyse financière</a>
-  <a href="/temoignages/">Témoignages</a>
-  <a href="/cartes-batailles/">Cartes &amp; batailles</a>
-  <a href="/archives/">Archives</a>
-  <a href="/premium/">Premium</a>
-  <a href="/a-propos/">À propos</a>
-  <a href="/contact/">Contact</a>
+  <a href="index.html">Accueil</a>
+  <a href="edition-semaine/">Édition de la semaine</a>
+  <a href="analyse-financiere/">Analyse financière</a>
+  <a href="temoignages/">Témoignages</a>
+  <a href="cartes-batailles/">Cartes &amp; batailles</a>
+  <a href="archives/">Archives</a>
+  <a href="premium/">Premium</a>
+  <a href="a-propos/">À propos</a>
+  <a href="contact/">Contact</a>
 </nav>
 
 <main>
@@ -25,9 +26,9 @@
 </main>
 <footer>
   <p>&copy; 2024 Nova Vox Interstellar. Tous droits réservés.</p>
-  <p><a href="/mentions-legales.html">Mentions légales</a> | <a href="/rss.xml">RSS</a></p>
+  <p><a href="mentions-legales.html">Mentions légales</a> | <a href="rss.xml">RSS</a></p>
 </footer>
 
-<script src="/assets/script.js"></script>
+<script src="assets/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `<base href="/sitev2/">` and switch site navigation to relative URLs for subdirectory deployment
- convert posts and pages to use shared header/footer and relative asset paths
- replace placeholder example article with an exploration guide and update post index metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4158786f0832f99e1df177c462ccd